### PR TITLE
Add a whole-program init hook.

### DIFF
--- a/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_library(LLVMInstrumentation
   AddressSanitizer.cpp
   BoundsChecking.cpp
+  CodeSpectatorInterface.cpp
   DataFlowSanitizer.cpp
   GCOVProfiling.cpp
   MemorySanitizer.cpp


### PR DESCRIPTION
It turns out that `__csi_init` was actually being called once per module. This PR renames that function call to `__csi_module_init` and implements new behavior for `__csi_init`.

Every module calls `__csi_module_init` as well as a helper function `__csi_rt_init_program`. The `rt` portion is short for "runtime" because that function has a tiny bit of runtime logic. The runtime logic is to ensure that `__csi_init` is called exactly once.

With this implementation, there is no guarantee as to the order of `__csi_module_init` and `__csi_init` calls.

This is the only way I could think to implement a "whole-program" init call, so let me know if anyone has better ideas.
