### PR TITLE
 Basic block hooks + CSI link-time pass

### DIFF
--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -127,6 +127,7 @@ void initializeAddressSanitizerModulePass(PassRegistry&);
 void initializeMemorySanitizerPass(PassRegistry&);
 void initializeThreadSanitizerPass(PassRegistry&);
 void initializeCodeSpectatorInterfacePass(PassRegistry&);
+void initializeCodeSpectatorInterfaceLTPass(PassRegistry&);
 void initializeSanitizerCoverageModulePass(PassRegistry&);
 void initializeDataFlowSanitizerPass(PassRegistry&);
 void initializeScalarizerPass(PassRegistry&);

--- a/include/llvm/Transforms/Instrumentation.h
+++ b/include/llvm/Transforms/Instrumentation.h
@@ -86,6 +86,8 @@ ModulePass *createInstrProfilingPass(
 // Insert CodeSpectatorInterface instrumentation
 // ANGE XXX: Should probably add different compiler flag options
 FunctionPass *createCodeSpectatorInterfacePass();
+// Insert CodeSpectatorInterface link-time pass
+ModulePass *createCodeSpectatorInterfaceLTPass();
 
 // Insert AddressSanitizer (address sanity checking) instrumentation
 FunctionPass *createAddressSanitizerFunctionPass(bool CompileKernel = false);

--- a/lib/LTO/LTOCodeGenerator.cpp
+++ b/lib/LTO/LTOCodeGenerator.cpp
@@ -49,6 +49,7 @@
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Target/TargetRegisterInfo.h"
 #include "llvm/Target/TargetSubtargetInfo.h"
+#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/ObjCARC.h"
@@ -102,6 +103,7 @@ LTOCodeGenerator::~LTOCodeGenerator() {
 void LTOCodeGenerator::initializeLTOPasses() {
   PassRegistry &R = *PassRegistry::getPassRegistry();
 
+  initializeCodeSpectatorInterfaceLTPass(R);
   initializeInternalizePassPass(R);
   initializeIPSCCPPass(R);
   initializeGlobalOptPass(R);

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Vectorize.h"
@@ -458,6 +459,9 @@ void PassManagerBuilder::populateModulePassManager(
 void PassManagerBuilder::addLTOOptimizationPasses(legacy::PassManagerBase &PM) {
   // Provide AliasAnalysis services for optimizations.
   addInitialAliasAnalysisPasses(PM);
+
+  // Add CodeSpectatorInterface instrumentation link-time support.
+  PM.add(createCodeSpectatorInterfaceLTPass());
 
   // Propagate constants at call sites into the functions they call.  This
   // opens opportunities for globalopt (and inlining) by substituting function

--- a/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_library(LLVMInstrumentation
   AddressSanitizer.cpp
   BoundsChecking.cpp
+  CodeSpectatorInterface.cpp
   DataFlowSanitizer.cpp
   GCOVProfiling.cpp
   MemorySanitizer.cpp

--- a/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
+++ b/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
@@ -404,6 +404,7 @@ bool CodeSpectatorInterfaceLT::runOnModule(Module &M) {
       assert(GV.hasInitializer());
       Constant *UniqueModuleId = ConstantInt::get(GV.getInitializer()->getType(), moduleId++);
       GV.setInitializer(UniqueModuleId);
+      GV.setConstant(true);
     }
   }
 

--- a/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
+++ b/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
@@ -405,6 +405,7 @@ bool CodeSpectatorInterfaceLT::runOnModule(Module &M) {
       assert(GV.hasInitializer());
       Constant *UniqueModuleId = ConstantInt::get(GV.getInitializer()->getType(), moduleId++);
       GV.setInitializer(UniqueModuleId);
+      modified = true;
     }
   }
   return modified;

--- a/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
+++ b/lib/Transforms/Instrumentation/CodeSpectatorInterface.cpp
@@ -322,10 +322,17 @@ bool CodeSpectatorInterface::instrumentBasicBlock(BasicBlock &BB) {
 bool CodeSpectatorInterface::doInitialization(Module &M) {
   DEBUG_WITH_TYPE("csi-func", errs() << "CSI_func: doInitialization" << "\n");
 
+  uint64_t NumBasicBlocks = 0;
+  IntegerType *Int64Ty = IntegerType::get(M.getContext(), 64);
+  for (Function &F : M) {
+      NumBasicBlocks += F.size();
+  }
+
   // Add call to module init
   std::tie(CsiModuleCtorFunction, std::ignore) = createSanitizerCtorAndInitFunctions(
-      M, CsiModuleCtorName, CsiModuleInitName, /*InitArgTypes=*/{},
-      /*InitArgs=*/{});
+      M, CsiModuleCtorName, CsiModuleInitName,
+      /*InitArgTypes=*/{Int64Ty},
+      /*InitArgs=*/{ConstantInt::get(Int64Ty, NumBasicBlocks)});
   appendToGlobalCtors(M, CsiModuleCtorFunction, 0);
 
   IntptrTy = M.getDataLayout().getIntPtrType(M.getContext());


### PR DESCRIPTION
Together with https://github.com/OpenKimono/compiler-rt/pull/3.

Now we have basic block entry/exit hooks. Basic blocks are given IDs unique within a module. Additionally each module has a unique ID.

I'll merge this in an hour or so if there are no issues.
